### PR TITLE
Correct typo (one too many spaces)

### DIFF
--- a/packages/keymaster_basic.yaml
+++ b/packages/keymaster_basic.yaml
@@ -106,7 +106,7 @@ automation:
     mode: queued
     max: 10
 
-   - alias: Lock Notifications
+  - alias: Lock Notifications
     description: "Notify when certain codes are used to unlock the doors, if notify is enabled"
     id: lock_notifications
     trigger:


### PR DESCRIPTION
Removed an extra space before "- alias" on Line 109 of keymaster_basic.yaml